### PR TITLE
Support separate output for failed to parse events

### DIFF
--- a/core/src/test/scala/com/snowplowanalytics/snowflake/core/ConfigSpec.scala
+++ b/core/src/test/scala/com/snowplowanalytics/snowflake/core/ConfigSpec.scala
@@ -31,6 +31,7 @@ class ConfigSpec extends Specification {
   Parse valid load without credentials $e9
   Parse valid base64-encoded events manifest configuration $e10
   Parse valid configuration with optional params $e11
+  Parse valid configuration with optional errorEventsUrl $e12
   """
 
   val configUrl = getClass.getResource("/valid-config.json")
@@ -72,6 +73,7 @@ class ConfigSpec extends Specification {
         warehouse = "snowplow_wh",
         database = "test_db",
         schema = "atomic",
+        errorEventsUrl = None,
         maxError = None,
         jdbcHost = None),
       "",
@@ -107,6 +109,7 @@ class ConfigSpec extends Specification {
         account = "snowplow",
         warehouse = "snowplow_wh",
         database = "test_db",
+        errorEventsUrl = None,
         maxError = None,
         jdbcHost = None),
       "",
@@ -144,6 +147,7 @@ class ConfigSpec extends Specification {
         account = "snowplow",
         warehouse = "snowplow_wh",
         database = "test_db",
+        errorEventsUrl = None,
         maxError = None,
         jdbcHost = None),
       "",
@@ -196,6 +200,7 @@ class ConfigSpec extends Specification {
         account = "snowplow",
         warehouse = "snowplow_wh",
         database = "test_db",
+        errorEventsUrl = None,
         maxError = None,
         jdbcHost = None),
       "",
@@ -233,6 +238,7 @@ class ConfigSpec extends Specification {
         account = "snowplow",
         warehouse = "snowplow_wh",
         database = "test_db",
+        errorEventsUrl = None,
         maxError = None,
         jdbcHost = None),
       "",
@@ -267,6 +273,7 @@ class ConfigSpec extends Specification {
         account = "snowplow",
         warehouse = "snowplow_wh",
         database = "test_db",
+        errorEventsUrl = None,
         maxError = None,
         jdbcHost = None),
       "",
@@ -300,6 +307,7 @@ class ConfigSpec extends Specification {
         account = "snowplow",
         warehouse = "snowplow_wh",
         database = "test_db",
+        errorEventsUrl = None,
         maxError = None,
         jdbcHost = None),
       Some(DynamoDbConfig(
@@ -346,6 +354,46 @@ class ConfigSpec extends Specification {
         account = "snowplow",
         warehouse = "snowplow_wh",
         database = "test_db",
+        errorEventsUrl = None,
+        maxError = Some(10000),
+        jdbcHost = Some("snowplow.us-west-1.azure.snowflakecomputing.com")),
+      "",
+      true)
+
+    Config.parseLoaderCli(args) must beSome(Right(expected))
+  }
+
+
+  def e12 = {
+    val args = List(
+      "load",
+
+      "--dry-run",
+      "--resolver", resolverBase64,
+      "--config", "ewogICJzY2hlbWEiOiAiaWdsdTpjb20uc25vd3Bsb3dhbmFseXRpY3Muc25vd3Bsb3cuc3RvcmFnZS9zbm93Zmxha2VfY29uZmlnL2pzb25zY2hlbWEvMS0wLTEiLAogICJkYXRhIjogewogICAgIm5hbWUiOiAiU25vd2ZsYWtlIiwKICAgICJhdXRoIjogewogICAgICAiYWNjZXNzS2V5SWQiOiAiQUJDRCIsCiAgICAgICJzZWNyZXRBY2Nlc3NLZXkiOiAiYWJjZCIKICAgIH0sCiAgICAiYXdzUmVnaW9uIjogInVzLWVhc3QtMSIsCiAgICAibWFuaWZlc3QiOiAic25vd2ZsYWtlLW1hbmlmZXN0IiwKICAgICJzbm93Zmxha2VSZWdpb24iOiAidXMtd2VzdC0xIiwKICAgICJkYXRhYmFzZSI6ICJ0ZXN0X2RiIiwKICAgICJpbnB1dCI6ICJzMzovL3Nub3dmbGFrZS9pbnB1dC8iLAogICAgInN0YWdlIjogInNvbWVfc3RhZ2UiLAogICAgInN0YWdlVXJsIjogInMzOi8vc25vd2ZsYWtlL291dHB1dC8iLAogICAgImVycm9yRXZlbnRzVXJsIjogInMzOi8vc25vd2ZsYWtlL2Vycm9ycyIsCiAgICAid2FyZWhvdXNlIjogInNub3dwbG93X3doIiwKICAgICJzY2hlbWEiOiAiYXRvbWljIiwKICAgICJhY2NvdW50IjogInNub3dwbG93IiwKICAgICJ1c2VybmFtZSI6ICJhbnRvbiIsCiAgICAicGFzc3dvcmQiOiAiU3VwZXJzZWNyZXQyIiwKICAgICJwdXJwb3NlIjogIkVOUklDSEVEX0VWRU5UUyIsCiAgICAibWF4RXJyb3IiOiAxMDAwMCwKICAgICJqZGJjSG9zdCI6ICJzbm93cGxvdy51cy13ZXN0LTEuYXp1cmUuc25vd2ZsYWtlY29tcHV0aW5nLmNvbSIKICB9Cn0K",
+      "--base64"
+    ).toArray
+
+    val expected = CliLoaderConfiguration(
+      Config.LoadCommand,
+      Config(
+        auth = Config.CredentialsAuth(
+          accessKeyId = "ABCD",
+          secretAccessKey = "abcd"
+        ),
+        awsRegion = "us-east-1",
+        manifest = "snowflake-manifest",
+        stage = "some_stage",
+        stageUrl = s3("s3://snowflake/output/"),
+        snowflakeRegion = "us-west-1",
+        schema = "atomic",
+        username = "anton",
+        password = Config.PlainText("Supersecret2"),
+        input = s3("s3://snowflake/input/"),
+        account = "snowplow",
+        warehouse = "snowplow_wh",
+        database = "test_db",
+        errorEventsUrl = Some(s3("s3://snowflake/errors")),
         maxError = Some(10000),
         jdbcHost = Some("snowplow.us-west-1.azure.snowflakecomputing.com")),
       "",

--- a/loader/src/test/scala/com/snowplowanalytics/snowflake/loader/LoaderSpec.scala
+++ b/loader/src/test/scala/com/snowplowanalytics/snowflake/loader/LoaderSpec.scala
@@ -79,6 +79,7 @@ class LoaderSpec extends Specification { def is = s2"""
       warehouse = "snowplow_wa",
       database = "database",
       schema = "not_an_atomic",
+      errorEventsUrl = None,
       maxError = None,
       jdbcHost = None)
 
@@ -141,6 +142,7 @@ class LoaderSpec extends Specification { def is = s2"""
       "wh",
       "db",
       "atomic",
+      None,
       None,
       None)
     Loader.exec(LoaderSpec.Mock, connection, new loader.LoaderSpec.ProcessingManifestTest, config)

--- a/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/Main.scala
+++ b/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/Main.scala
@@ -39,7 +39,7 @@ object Main {
 
         runFolders match {
           case Right(folders) =>
-            val configs = folders.map(TransformerJobConfig(appConfig.input, appConfig.stageUrl, _))
+            val configs = folders.map(TransformerJobConfig(appConfig.input, appConfig.stageUrl, appConfig.errorEventsUrl, _))
             TransformerJob.run(spark, manifest, appConfig.manifest, configs, eventsManifestConfig, inbatch)
           case Left(error) =>
             println("Cannot get list of unprocessed folders")

--- a/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/TransformerJobConfig.scala
+++ b/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/TransformerJobConfig.scala
@@ -14,7 +14,7 @@ package com.snowplowanalytics.snowflake.transformer
 
 import com.snowplowanalytics.snowflake.core.Config._
 
-case class TransformerJobConfig(enrichedArchive: S3Folder, snowflakeOutput: S3Folder, runId: String) {
+case class TransformerJobConfig(enrichedArchive: S3Folder, snowflakeOutput: S3Folder, errorEventsOutput: Option[S3Folder], runId: String) {
   def input: String = {
     val (enrichedBucket, enrichedPath) = enrichedArchive.splitS3Folder
     s"s3a://$enrichedBucket/$enrichedPath$runIdFolder/*"
@@ -25,13 +25,15 @@ case class TransformerJobConfig(enrichedArchive: S3Folder, snowflakeOutput: S3Fo
     s"s3a://$bucket/$path$runIdFolder"
   }
 
-  def badOutput: String = {
-    val (bucket, path) = snowflakeOutput.splitS3Folder
-    s"s3a://$bucket/$path$runIdFolder$bad"
+  def errorOutput: Option[String] = {
+    errorEventsOutput match {
+      case Some(f) =>
+        val (bucket, path) = f.splitS3Folder
+        Some(s"s3a://$bucket/$path$runIdFolder")
+      case None => None
+    }
   }
 
   def runIdFolder: String = runId.split("/").last
-
-  def bad: String = "_BAD"
 }
 

--- a/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/TransformerJobConfig.scala
+++ b/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/TransformerJobConfig.scala
@@ -25,6 +25,13 @@ case class TransformerJobConfig(enrichedArchive: S3Folder, snowflakeOutput: S3Fo
     s"s3a://$bucket/$path$runIdFolder"
   }
 
+  def badOutput: String = {
+    val (bucket, path) = snowflakeOutput.splitS3Folder
+    s"s3a://$bucket/$path$runIdFolder$bad"
+  }
+
   def runIdFolder: String = runId.split("/").last
+
+  def bad: String = "_BAD"
 }
 


### PR DESCRIPTION
## Rationale:
The loader throws an uncaught [`RuntimeException`](https://github.com/snowplow-incubator/snowplow-snowflake-loader/blob/a069f916171a971f551ba8d48e24d7c083588b50/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/Transformer.scala#L61) when encountering an invalid line in the input TSV file. This means any upstream enrichments that corrupt a line will cause the entire file to fail. This PR instead skips invalid lines and collects them to optionally be written to a separate `errorEvents` bucket on S3.

## Changes include:
* Lines containing JSON parse errors that do not impact shredding are skipped. An example of this error is: `Context JSON did not contain a stringly typed schema field`.
* Events (lines) that fail to be parsed are logged to stdout including line number, filename, reason, and line contents.
* An optional configuration ‘badEventsUrl' parameter is added of type `Option[S3Folder]`. If the parameter is set, error events will be written to a file in this bucket. The filename is identical to the source filename from which the event originated.

## Notes:
* The implementation uses `wholeTextFile` instead of `textFile`. This means large files are no longer split into 32MB chunks and paralellized, but this should not be a problem because files do not tend to be this large.
* If mandatory snowplow fields are missing, this will cause an error in the shredding process we cannot recover from. This is not a problem because this error should never occur and something is seriously wrong upstream if it does.

## TODO:
* Add an optional `errorEventsUrl` field to schema and bump version to `com.snowplowanalytics.snowplow.storage/snowflake_config/jsonschema/1-0-2`.
* Fix failing configuration spec test by changing schema version to 1-0-2.
